### PR TITLE
when chroot, ignore environment variables

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -146,10 +146,10 @@ create_img() {
 	echo "127.0.0.1\tlocalhost" >${_MNT}/etc/hosts
 	echo "::1\t\tlocalhost" >>${_MNT}/etc/hosts
 	sed -i "s/^#\(PermitRootLogin\) .*/\1 no/" ${_MNT}/etc/ssh/sshd_config
-	chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-	chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
-	chroot ${_MNT} rcctl disable sndiod
-	chroot ${_MNT} useradd -G wheel -L staff -c 'EC2 Default User' -g =uid \
+	env -i chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+	env -i chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
+	env -i chroot ${_MNT} rcctl disable sndiod
+	env -i chroot ${_MNT} useradd -G wheel -L staff -c 'EC2 Default User' -g =uid \
 		-m -u 1000 ec2-user
 	echo "permit nopass ec2-user" >${_MNT}/etc/doas.conf
 	echo "ec2-user" >${_MNT}/root/.forward

--- a/create-az.sh
+++ b/create-az.sh
@@ -164,10 +164,10 @@ create_img() {
 	echo "127.0.0.1\tlocalhost" >${_MNT}/etc/hosts
 	echo "::1\t\tlocalhost" >>${_MNT}/etc/hosts
 	sed -i "s/^#\(PermitRootLogin\) .*/\1 no/" ${_MNT}/etc/ssh/sshd_config
-	chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-	chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
-	chroot ${_MNT} rcctl disable sndiod
-	chroot ${_MNT} sha256 -h /var/db/kernel.SHA256 /bsd
+	env -i chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+	env -i chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
+	env -i chroot ${_MNT} rcctl disable sndiod
+	env -i chroot ${_MNT} sha256 -h /var/db/kernel.SHA256 /bsd
 
 	# If the rc.cloud file is not found, fallback to the sysmerge method.
 	if [[ -s "$RC_CLOUD" ]]; then


### PR DESCRIPTION
fixes rcctl failure when TMPDIR is set.

same as in https://github.com/ajacoutot/aws-openbsd/pull/32